### PR TITLE
WIP: Streaming Compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,17 @@
+# Profile Build
+[profile.profile]
+inherits = "release"
+debug = true
+codegen-units = 1
+lto = true
+strip = false  # No stripping!!
+
+# Optimized Release Build
+[profile.release]
+codegen-units = 1
+lto = true
+strip = true  # Automatically strip symbols from the binary.
+panic = "abort"
 
 [workspace]
 members = [
@@ -6,3 +20,4 @@ members = [
     # Tool to test dictionary compression
     "projects/research/dictionary-tester"
 ]
+resolver = "2"

--- a/projects/sewer56-archives-nx/Cargo.toml
+++ b/projects/sewer56-archives-nx/Cargo.toml
@@ -51,6 +51,7 @@ hashbrown = { version = "0.15.2" }
 nanokit = "0.2.0"
 num_cpus = { version = "1.16.0", optional = true }
 derive-new = "0.7.0"
+derive_more = {version = "1.0.0", features = ["deref", "deref_mut"]}
 ahash = "0.8.11"
 endian-writer = "2.2.0"
 endian-writer-derive = "0.1.0"

--- a/projects/sewer56-archives-nx/Cargo.toml
+++ b/projects/sewer56-archives-nx/Cargo.toml
@@ -17,7 +17,7 @@ nightly = ["allocator-api2/nightly", "hashbrown/nightly", "safe-allocator-api/ni
 pgo = []
 
 # Enables support for LZ4 compression/decompression
-lz4 = []
+lz4 = ["lz4-sys"]
 
 # Adds additional runtime checks against untrusted input.
 # This is useful if you receive NX2 files from the internet.
@@ -41,7 +41,7 @@ miri_extra_checks = []
 
 [dependencies]
 bitfield = "0.17.0"
-lzzzz = "1.1.0"
+lz4-sys = { version = "1.11.1", optional = true }
 zstd-sys = {version = "2.0.13", features = ["experimental"]} # 1.5.6
 no-panic = "0.1.32"
 int-enum = "1.1.2"
@@ -74,21 +74,6 @@ tempfile = "3.14.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
-
-# Profile Build
-[profile.profile]
-inherits = "release"
-debug = true
-codegen-units = 1
-lto = true
-strip = false  # No stripping!!
-
-# Optimized Release Build
-[profile.release]
-codegen-units = 1
-lto = true
-strip = true  # Automatically strip symbols from the binary.
-panic = "abort"
 
 # Benchmark Stuff
 [[bench]]

--- a/projects/sewer56-archives-nx/src/utilities/compression/dictionary/compress.rs
+++ b/projects/sewer56-archives-nx/src/utilities/compression/dictionary/compress.rs
@@ -1,3 +1,5 @@
+use crate::utilities::compression::copy;
+
 use super::super::{CompressionResult, NxCompressionError};
 use core::ffi::c_void;
 use core::ptr::NonNull;
@@ -72,13 +74,7 @@ impl ZstdCompressionDict {
 
         let errcode = unsafe { ZSTD_getErrorCode(result) };
         if result > source.len() || errcode == ZSTD_error_dstSize_tooSmall {
-            return super::super::compress(
-                super::super::CompressionPreference::Copy,
-                0,
-                source,
-                destination,
-                used_copy,
-            );
+            return copy::compress(source, destination, used_copy);
         }
 
         if unsafe { ZSTD_isError(result) } == 0 {

--- a/projects/sewer56-archives-nx/src/utilities/compression/lz4.rs
+++ b/projects/sewer56-archives-nx/src/utilities/compression/lz4.rs
@@ -1,5 +1,8 @@
+use core::cmp::min;
+
 use super::{CompressionResult, DecompressionResult};
 use crate::api::enums::*;
+use lz4_sys::*;
 use thiserror_no_std::Error;
 
 /// Represents an error specific to LZ4 compression operations.
@@ -26,7 +29,7 @@ pub enum Lz4DecompressionError {
 ///
 /// * `source_length`: Number of bytes at source.
 pub fn max_alloc_for_compress_size(source_length: usize) -> usize {
-    lzzzz::lz4::max_compressed_size(source_length)
+    unsafe { LZ4_compressBound(source_length as i32) as usize }
 }
 
 /// Compresses data with LZ4.
@@ -49,17 +52,24 @@ pub fn compress(
 ) -> CompressionResult {
     *used_copy = false;
 
-    let bytes = lzzzz::lz4_hc::compress(source, destination, level);
+    let result = unsafe {
+        LZ4_compress_HC(
+            source.as_ptr() as *const c_char,
+            destination.as_mut_ptr() as *mut c_char,
+            source.len() as c_int,
+            destination.len() as c_int,
+            level as c_int,
+        )
+    };
 
-    if bytes.is_err() {
+    if result == 0 {
         // LZ4 only has 1 error
         return Err(Lz4CompressionError::CompressionFailed.into());
     }
 
     // Note: This code assumes that the user has properly used max_alloc_for_compress_size
     //       failure to do so will result in possible CompressionFailed error.
-    let num_bytes = unsafe { bytes.unwrap_unchecked() } as usize;
-    if unsafe { bytes.unwrap_unchecked() } > source.len() {
+    if result > source.len() as i32 {
         return super::compress(
             CompressionPreference::Copy,
             level,
@@ -69,7 +79,111 @@ pub fn compress(
         );
     }
 
-    Ok(num_bytes)
+    Ok(result as usize)
+}
+
+/// Compresses data using streaming compression with LZ4-HC.
+///
+/// This function allows compression of data in chunks while providing the ability
+/// to terminate compression early through a callback function. Data is processed
+/// in blocks of 128KB.
+///
+/// # Parameters
+///
+/// * `level`: Compression level to use.
+/// * `source`: Source data to compress.
+/// * `destination`: Destination buffer for compressed data.
+/// * `terminate_early`: Optional callback that returns `Some(i32)` to terminate early
+///   with that value, or `None` to continue compression.
+/// * `used_copy`: If this is true, Copy compression was used, due to uncompressible data.
+///
+/// # Returns
+///
+/// * `Ok(usize)`: The number of bytes written to the destination.
+/// * `Err(NxCompressionError)`: If compression fails.
+///
+/// # Safety
+///
+/// This function uses unsafe code to interact with the LZ4 C API.
+pub fn compress_streamed<F>(
+    level: i32,
+    source: &[u8],
+    destination: &mut [u8],
+    terminate_early: Option<F>,
+    used_copy: &mut bool,
+) -> CompressionResult
+where
+    F: Fn() -> Option<i32>,
+{
+    *used_copy = false;
+    const BLOCK_SIZE: usize = 131072;
+
+    unsafe {
+        // Create LZ4 HC stream
+        let stream = LZ4_createStreamHC();
+        if stream.is_null() {
+            return Err(Lz4CompressionError::CompressionFailed.into());
+        }
+
+        // Set compression level
+        LZ4_setCompressionLevel(stream, level);
+
+        let result = {
+            let mut total_written = 0;
+            let mut total_read = 0;
+            let source_len = source.len();
+
+            while total_read < source_len {
+                // Calculate chunk size for this iteration
+                let remaining = source_len - total_read;
+                let chunk_size = min(BLOCK_SIZE, remaining);
+
+                // Compress the current chunk
+                let num_compressed = LZ4_compress_HC_continue(
+                    stream,
+                    // SAFETY: total_read is less than source_len, guaranteed by loop above.
+                    source.as_ptr().add(total_read) as *const c_char,
+                    destination.as_mut_ptr().add(total_written) as *mut c_char,
+                    chunk_size as c_int,
+                    (destination.len() - total_written) as c_int,
+                );
+
+                if num_compressed <= 0 {
+                    LZ4_freeStreamHC(stream);
+                    return Err(Lz4CompressionError::CompressionFailed.into());
+                }
+
+                // Check for early termination
+                if let Some(ref callback) = terminate_early {
+                    if let Some(early_result) = callback() {
+                        LZ4_freeStreamHC(stream);
+                        return Ok(early_result as usize);
+                    }
+                }
+
+                // Check if compression is efficient for this chunk
+                if num_compressed as usize > chunk_size {
+                    LZ4_freeStreamHC(stream);
+                    return super::compress(
+                        super::CompressionPreference::Copy,
+                        level,
+                        source,
+                        destination,
+                        used_copy,
+                    );
+                }
+
+                total_written += num_compressed as usize;
+                total_read += chunk_size;
+            }
+
+            Ok(total_written)
+        };
+
+        // Clean up
+        LZ4_freeStreamHC(stream);
+        result
+    }
 }
 
 /// Decompresses data with LZ4.
@@ -83,12 +197,20 @@ pub fn compress(
 ///
 /// The number of bytes written to the destination, or an error.
 pub fn decompress(source: &[u8], destination: &mut [u8]) -> DecompressionResult {
-    let result = lzzzz::lz4::decompress(source, destination);
+    let result = unsafe {
+        LZ4_decompress_safe(
+            source.as_ptr() as *const c_char,
+            destination.as_mut_ptr() as *mut c_char,
+            source.len() as c_int,
+            destination.len() as c_int,
+        )
+    };
 
-    match result {
-        Ok(num_bytes) => Ok(num_bytes),
+    if result <= 0 {
         // LZ4 only has a single 'decompression failed', so we don't need to check error type.
-        Err(_) => Err(Lz4DecompressionError::DecompressionFailed.into()),
+        Err(Lz4DecompressionError::DecompressionFailed.into())
+    } else {
+        Ok(result as usize)
     }
 }
 
@@ -103,11 +225,146 @@ pub fn decompress(source: &[u8], destination: &mut [u8]) -> DecompressionResult 
 ///
 /// The number of bytes written to the destination, or an error.
 pub fn decompress_partial(source: &[u8], destination: &mut [u8]) -> DecompressionResult {
-    let result = lzzzz::lz4::decompress_partial(source, destination, destination.len());
+    let result = unsafe {
+        LZ4_decompress_safe_partial(
+            source.as_ptr() as *const c_char,
+            destination.as_mut_ptr() as *mut c_char,
+            source.len() as c_int,
+            destination.len() as c_int,
+            destination.len() as c_int,
+        )
+    };
 
-    match result {
-        Ok(num_bytes) => Ok(num_bytes),
+    if result <= 0 {
         // LZ4 only has a single 'decompression failed', so we don't need to check error type.
-        Err(_) => Err(Lz4DecompressionError::DecompressionFailed.into()),
+        Err(Lz4DecompressionError::DecompressionFailed.into())
+    } else {
+        Ok(result as usize)
+    }
+}
+
+// Missing bindings from lz4-sys declared here.
+extern "C" {
+    #[allow(non_snake_case)]
+    pub fn LZ4_decompress_safe_partial(
+        source: *const c_char,
+        dest: *mut c_char,
+        sourceSize: c_int,
+        targetOutputSize: c_int,
+        maxDestSize: c_int,
+    ) -> c_int;
+
+    #[allow(non_snake_case)]
+    pub fn LZ4_createStreamHC() -> *mut LZ4StreamEncode;
+
+    #[allow(non_snake_case)]
+    pub fn LZ4_freeStreamHC(ptr: *mut LZ4StreamEncode) -> c_int;
+
+    #[allow(non_snake_case)]
+    pub fn LZ4_setCompressionLevel(ptr: *mut LZ4StreamEncode, compression_level: c_int);
+
+    #[allow(non_snake_case)]
+    pub fn LZ4_compress_HC_continue(
+        ptr: *mut LZ4StreamEncode,
+        src: *const c_char,
+        dst: *mut c_char,
+        src_size: c_int,
+        dst_capacity: c_int,
+    ) -> c_int;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::max_alloc_for_compress_size;
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn compress_streamed_basic() {
+        let original_data = b"Hello, LZ4!".repeat(100_000); // Large enough to test multiple chunks
+        let mut compressed = vec![0u8; max_alloc_for_compress_size(original_data.len())];
+        let mut used_copy = false;
+
+        let result = compress_streamed(
+            3,
+            &original_data,
+            &mut compressed,
+            None as Option<fn() -> Option<i32>>,
+            &mut used_copy,
+        )
+        .unwrap();
+
+        assert!(!used_copy, "Should not have used copy compression");
+        assert!(result > 0, "Should have compressed some data");
+        assert!(
+            result < original_data.len(),
+            "Should achieve some compression"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn compress_streamed_early_termination() {
+        let original_data = b"Hello, LZ4!".repeat(100_000);
+        let mut compressed = vec![0u8; max_alloc_for_compress_size(original_data.len())];
+        let mut used_copy = false;
+
+        let early_return_value = 42;
+        let result = compress_streamed(
+            3,
+            &original_data,
+            &mut compressed,
+            Some(|| Some(early_return_value)),
+            &mut used_copy,
+        )
+        .unwrap();
+
+        assert_eq!(
+            result, early_return_value as usize,
+            "Should return early with callback value"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn compress_streamed_small_destination() {
+        let original_data = b"Hello, LZ4!".repeat(100_000);
+        let mut compressed = vec![0u8; 10]; // Too small destination buffer
+        let mut used_copy = false;
+
+        let result = compress_streamed(
+            3,
+            &original_data,
+            &mut compressed,
+            None as Option<fn() -> Option<i32>>,
+            &mut used_copy,
+        );
+
+        assert!(result.is_err(), "Should fail");
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn compress_streamed_multiple_chunks() {
+        let original_data = b"Hello, LZ4!".repeat(200_000); // Ensures multiple chunks
+        let mut compressed = vec![0u8; max_alloc_for_compress_size(original_data.len())];
+        let mut used_copy = false;
+
+        let result = compress_streamed(
+            3,
+            &original_data,
+            &mut compressed,
+            None as Option<fn() -> Option<i32>>,
+            &mut used_copy,
+        )
+        .unwrap();
+
+        assert!(!used_copy, "Should not have used copy compression");
+        assert!(result > 0, "Should have compressed some data");
+        assert!(
+            result < original_data.len(),
+            "Should achieve some compression"
+        );
     }
 }

--- a/projects/sewer56-archives-nx/src/utilities/compression/zstd.rs
+++ b/projects/sewer56-archives-nx/src/utilities/compression/zstd.rs
@@ -153,7 +153,8 @@ where
                 pos: 0,
             };
 
-            loop {
+            let mut finished = false;
+            while !finished {
                 let result = ZSTD_compressStream2(*cstream, &mut output, &mut input, mode);
 
                 // Check if zstd returned an error, or no bytes were compressed in this iteration.
@@ -175,15 +176,12 @@ where
                 // If we're on the last chunk we're finished when zstd returns 0,
                 // which means its consumed all the input AND finished the frame.
                 // Otherwise, we're finished when we've consumed all the input.
-                let finished = if last_chunk {
+                // Note: Copied from zstd example.
+                finished = if last_chunk {
                     result == 0
                 } else {
                     input.pos == input.size
                 };
-
-                if finished {
-                    break;
-                }
             }
 
             total_read += input.pos;


### PR DESCRIPTION

- Streaming compression (compress in blocks, with opportunity for early termination).
- Moved profiles to root `Cargo.toml`.
- lz4 crate now uses `lz4-sys`, with some extra manual bindings.