### PR TITLE
Improved: Migrate all zstd compression to minimized frame size format.

### DIFF
--- a/projects/sewer56-archives-nx/Cargo.toml
+++ b/projects/sewer56-archives-nx/Cargo.toml
@@ -23,10 +23,6 @@ lz4 = ["lz4-sys"]
 # This is useful if you receive NX2 files from the internet.
 hardened = []
 
-# Panics with full error text on unhandled ZStandard Errors.
-# Increases binary size in favour of better error messages.
-zstd_panic_on_unhandled_error = []
-
 # Avoids core::fmt to reduce binary size.
 # May reduce error message friendliness.
 no_format = [ "lightweight-mmap/no-format" ]
@@ -42,7 +38,7 @@ miri_extra_checks = []
 [dependencies]
 bitfield = "0.17.0"
 lz4-sys = { version = "1.11.1", optional = true }
-zstd-sys = {version = "2.0.13", features = ["experimental"]} # 1.5.6
+zstd-sys = {version = "2.0.13", features = ["experimental"] } # 1.5.6
 no-panic = "0.1.32"
 int-enum = "1.1.2"
 thiserror-no-std = "2.0.2"

--- a/projects/sewer56-archives-nx/benches/my_benchmark/assets.rs
+++ b/projects/sewer56-archives-nx/benches/my_benchmark/assets.rs
@@ -1,5 +1,5 @@
 use sewer56_archives_nx::utilities::compression::zstd::*;
-use std::fs::read;
+use std::{fs::read, os::raw::c_void};
 
 pub fn get_yakuza_file_list() -> Vec<String> {
     let compressed_data =
@@ -8,7 +8,15 @@ pub fn get_yakuza_file_list() -> Vec<String> {
         get_decompressed_size(&compressed_data).expect("Failed to get decompressed size");
 
     let mut decompressed_data = vec![0u8; decompressed_size];
-    decompress(&compressed_data, &mut decompressed_data).expect("Failed to decompress data");
+    unsafe {
+        zstd_sys::ZSTD_decompress(
+            decompressed_data.as_mut_ptr() as *mut c_void,
+            decompressed_size,
+            compressed_data.as_ptr() as *const c_void,
+            compressed_data.len(),
+        );
+        decompressed_data.set_len(decompressed_size);
+    }
 
     String::from_utf8(decompressed_data)
         .expect("Failed to convert decompressed data to UTF-8")

--- a/projects/sewer56-archives-nx/src/headers/parser/dictionary/dictionary_builder.rs
+++ b/projects/sewer56-archives-nx/src/headers/parser/dictionary/dictionary_builder.rs
@@ -169,7 +169,7 @@ where
             let max_compressed_size =
                 compression::zstd::max_alloc_for_compress_size(decompressed_size as usize);
             let mut compressed_data: Vec<u8> = Vec::with_capacity(max_compressed_size);
-            let num_written_bytes = compression::zstd::compress_no_copy_fallback(
+            let num_written_bytes = compression::zstd::force_compress(
                 DEFAULT_COMPRESSION_LEVEL,
                 slice::from_raw_parts(start_ptr, decompressed_size as usize),
                 slice::from_raw_parts_mut(compressed_data.as_mut_ptr(), compressed_data.capacity()),

--- a/projects/sewer56-archives-nx/src/headers/parser/string_pool_common.rs
+++ b/projects/sewer56-archives-nx/src/headers/parser/string_pool_common.rs
@@ -184,4 +184,7 @@ pub enum StringPoolUnpackError {
 
     /// The StringPool should end on a null terminator, but it does not.
     ShouldEndOnNullTerminator,
+
+    /// There is insufficient data to deserialize the string pool.
+    NotEnoughData,
 }

--- a/projects/sewer56-archives-nx/src/utilities/compression/zstd_stream.rs
+++ b/projects/sewer56-archives-nx/src/utilities/compression/zstd_stream.rs
@@ -1,3 +1,4 @@
+use super::zstd::zstd_setcommondecompressionparams;
 use super::{DecompressionResult, NxDecompressionError};
 use core::ffi::c_void;
 use zstd_sys::ZSTD_ErrorCode::ZSTD_error_memory_allocation;
@@ -35,6 +36,8 @@ impl<'a> ZstdDecompressor<'a> {
                     ZSTD_error_memory_allocation,
                 ));
             }
+
+            zstd_setcommondecompressionparams(d_stream);
 
             Ok(ZstdDecompressor {
                 d_stream,
@@ -179,7 +182,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn handles_invalid_data() {
-        let invalid_data = vec![0u8; 100];
+        let invalid_data = vec![0xFFu8; 100];
         let mut decompressor = ZstdDecompressor::new(&invalid_data).unwrap();
         let mut output = vec![0u8; 1000];
 


### PR DESCRIPTION
See the updated 'overview' section in the PR for the details.
We're basically trimming off 10 bytes per zstd compressed block :p