### PR TITLE
Improved: LLM Assisted Cleanup Session

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,12 @@ jobs:
           - { os: ubuntu-latest, target: x86_64-pc-windows-gnu, use-pgo: false, use-cross: true, toolchain: stable } # test only, and has issues
           - { os: ubuntu-latest, target: i686-pc-windows-gnu, use-pgo: false, use-cross: true, toolchain: stable } # test only, and has issues
 
+          # Big Endian
+          - { os: ubuntu-latest, target: powerpc-unknown-linux-gnu, use-pgo: false, use-cross: true, toolchain: nightly, features: nightly } # 32-bit big endian
+          - { os: ubuntu-latest, target: powerpc64-unknown-linux-gnu, use-pgo: false, use-cross: true, toolchain: nightly, features: nightly } # 64-bit big endian
+          - { os: ubuntu-latest, target: powerpc-unknown-linux-gnu, use-pgo: false, use-cross: true, toolchain: stable } # 32-bit big endian
+          - { os: ubuntu-latest, target: powerpc64-unknown-linux-gnu, use-pgo: false, use-cross: true, toolchain: stable } # 64-bit big endian
+
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# Rules for sewer56-archives-nx
+
+## Project Overview
+
+This is a modern, efficient archive format optimized for use in games. The library provides high-performance compression support, SIMD optimizations, and no_std compatibility.
+
+## Project Structure
+
+The project is organized into several main directories:
+
+- **`/projects/sewer56-archives-nx/`** - Houses the main library implementation
+  - `src/api/` - Public API interfaces and traits
+  - `src/headers/` - Archive format headers and parsers
+  - `src/implementation/` - Core implementation logic
+  - `src/utilities/` - Utility functions and helpers
+  - `benches/` - Performance benchmarks using criterion
+
+- **`/projects/research/`** - Research tools and experiments (not production ready, research only)
+  - Dictionary compression analysis tools
+  - Mod archive statistics gathering
+  - Compression algorithm comparisons
+
+- **`/docs/`** - Documentation and specifications
+  - Archive format specifications
+  - Implementation details
+  - Research findings
+
+## Code Style & Formatting
+
+### Rust Formatting
+
+- Use proper rustdoc format with elements in brackets like [`Type`] instead of `Type`
+- Maintain original code order and all comments intact unless explicitly permitted
+- Try not to exceed 500 lines per module (excluding tests); split larger modules when necessary
+
+### Variable Names & Structure
+
+- Preserve existing coding style: keep variable names and loop structures unchanged unless explicitly instructed
+- Follow Rust naming conventions (snake_case for functions/variables, PascalCase for types)
+- Use descriptive names for performance-critical code
+
+### Import and Dependency Preferences
+
+- Prefer `core` over `std` when possible for better no_std compatibility
+- Prefer using short names and `use` statements at the top of the file
+- Only place `use` statements inside functions with conditional compilation flags like `#[cfg(...)]`
+
+## Documentation Standards
+
+### Function Documentation
+
+- Use comprehensive rustdoc comments `///` for all public functions
+- Include detailed Safety sections for unsafe functions covering:
+  - Pointer validity requirements
+  - Memory alignment recommendations
+  - Buffer overlap restrictions
+  - Size requirements and divisibility constraints
+- Include Parameters and Returns sections
+- Add Remarks section for complex behaviors or performance notes
+
+### Examples
+
+- Include code examples in documentation when helpful
+- Show both basic usage and safety requirements
+
+### Error Handling
+
+- Maintain consistent error types across modules
+
+## Backwards Compatibility
+
+- The crates are not yet released; therefore, you may make backwards incompatible changes. Do not however rename methods unless it is necessary.
+
+## Post-Change Verification
+
+**CRITICAL: After making any code changes, ALWAYS perform these verification steps in order:**
+
+1. **Run Tests**: Execute `cargo test --all-features` to ensure all functionality works correctly
+2. **Auto-fix Clippy Issues**: Run `cargo clippy --fix --allow-dirty --all-features` to automatically fix linting issues
+3. **Check Remaining Lints**: Run `cargo clippy --workspace --all-features -- -D warnings` to catch any remaining warnings
+4. **Verify Documentation**: Run `cargo doc --workspace --all-features` to check for documentation errors
+5. **Fix Documentation Links**: For any broken doc links, use the proper format: `` [`function_name`]: crate::function_name ``
+6. **Big Endian Testing** If `cross` is installed, run:
+   ```
+   cross test --package sewer56-archives-nx --target powerpc64-unknown-linux-gnu
+   ```
+7. **Format Code**: Run `cargo fmt --all` as the final step to ensure consistent formatting
+
+These steps are mandatory and must be completed successfully before considering any code change complete.

--- a/flake.nix
+++ b/flake.nix
@@ -32,13 +32,18 @@
     overlays.default = final: prev: {
       rustToolchain = with inputs.fenix.packages.${prev.stdenv.hostPlatform.system};
         combine (
-          with latest; [
-            clippy
-            rustc
-            cargo
-            rustfmt
-            rust-src
-          ]
+          with latest;
+            [
+              clippy
+              rustc
+              cargo
+              rustfmt
+              rust-src
+            ]
+            ++ [
+              targets.powerpc64-unknown-linux-gnu.latest.rust-std
+              targets.powerpc-unknown-linux-gnu.latest.rust-std
+            ]
         );
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
             LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
             C_INCLUDE_PATH = "${pkgs.glibc.dev}/include";
             CPLUS_INCLUDE_PATH = "${pkgs.glibc.dev}/include";
+            CROSS_CUSTOM_TOOLCHAIN = "1";
           };
 
           shellHook = ''

--- a/projects/sewer56-archives-nx/src/api/filedata/input/from_boxed_slice_provider.rs
+++ b/projects/sewer56-archives-nx/src/api/filedata/input/from_boxed_slice_provider.rs
@@ -7,7 +7,7 @@ pub struct FromBoxedSliceProvider {
 }
 
 impl FromBoxedSliceProvider {
-    /// Creates a new [`FromArrayProvider`] with the given boxed byte slice.
+    /// Creates a new [`FromBoxedSliceProvider`] with the given boxed byte slice.
     pub fn new(data: Box<[u8]>) -> Self {
         Self { data }
     }

--- a/projects/sewer56-archives-nx/src/api/filedata/input/from_slice_reference_provider.rs
+++ b/projects/sewer56-archives-nx/src/api/filedata/input/from_slice_reference_provider.rs
@@ -7,7 +7,7 @@ pub struct FromSliceReferenceProvider<'a> {
 }
 
 impl<'a> FromSliceReferenceProvider<'a> {
-    /// Creates a new [`FromArrayProvider`] with the given slice reference.
+    /// Creates a new [`FromSliceReferenceProvider`] with the given slice reference.
     pub fn new(data: &'a [u8]) -> Self {
         Self { data }
     }

--- a/projects/sewer56-archives-nx/src/api/packer_builder.rs
+++ b/projects/sewer56-archives-nx/src/api/packer_builder.rs
@@ -489,7 +489,7 @@ pub struct AddFileParams {
     pub relative_path: String,
 
     /// Preferred algorithm to compress the item with. This setting is only
-    /// honored if [`SolidPreference::NoSolid`] is set in [`solid_type`].
+    /// honored if [`SolidPreference::NoSolid`] is set in [`Self::solid_type`].
     ///
     /// If no preference is specified (`NoPreference`), the archive's default
     /// compression algorithm will be used.

--- a/projects/sewer56-archives-nx/src/api/packing/packing_settings.rs
+++ b/projects/sewer56-archives-nx/src/api/packing/packing_settings.rs
@@ -40,7 +40,7 @@ pub struct PackingSettings {
     /// Range is 32768 (32K) to 1073741824 (1 GiB).\
     /// Values are powers of 2.
     ///
-    /// Must be greater than [`Self::block_size`].
+    /// Must be greater than [`Self::solid_size`].
     pub chunk_size: u32,
 
     /// Set this to 'true' to store hashes in the ToC.

--- a/projects/sewer56-archives-nx/src/api/traits/has_relative_path.rs
+++ b/projects/sewer56-archives-nx/src/api/traits/has_relative_path.rs
@@ -10,7 +10,7 @@ pub trait HasRelativePath {
     fn relative_path(&self) -> &str;
 }
 
-/// Automatic implementation of [HasRelativePath] for [Rc<T>]
+/// Automatic implementation of [`HasRelativePath`] for [`Rc<T>`]
 impl<T: HasRelativePath> HasRelativePath for Rc<T> {
     fn relative_path(&self) -> &str {
         self.as_ref().relative_path()

--- a/projects/sewer56-archives-nx/src/headers/managed/v1/table_of_contents_builder.rs
+++ b/projects/sewer56-archives-nx/src/headers/managed/v1/table_of_contents_builder.rs
@@ -21,7 +21,7 @@ const MAX_FILE_COUNT_V0V1: usize = 1048575; // 2^20 - 1
 ///
 /// # Arguments
 ///
-/// * `blocks` - A slice of [Box<dyn Block<T>>] representing the blocks in the archive.
+/// * `blocks` - A slice of [`Box<dyn Block<T>>`] representing the blocks in the archive.
 ///
 /// # Returns
 ///
@@ -139,8 +139,8 @@ pub fn pack_string_pool_with_allocators<
 /// # Errors
 ///
 /// This function will return an error if:
-/// - The number of blocks exceeds [MAX_BLOCK_COUNT_V0V1].
-/// - The number of file entries exceeds [MAX_FILE_COUNT_V0V1].
+/// - The number of blocks exceeds MAX_BLOCK_COUNT_V0V1.
+/// - The number of file entries exceeds MAX_FILE_COUNT_V0V1.
 #[allow(dead_code)] // TODO: This is temporary
 pub(crate) unsafe fn serialize_table_of_contents_from_state(
     builder_state: &TableOfContentsBuilderState,
@@ -189,8 +189,8 @@ pub(crate) unsafe fn serialize_table_of_contents_from_state(
 /// # Errors
 ///
 /// This function will return an error if:
-/// - The number of blocks exceeds [MAX_BLOCK_COUNT_V0V1].
-/// - The number of file entries exceeds [MAX_FILE_COUNT_V0V1].
+/// - The number of blocks exceeds MAX_BLOCK_COUNT_V0V1.
+/// - The number of file entries exceeds MAX_FILE_COUNT_V0V1.
 pub unsafe fn serialize_table_of_contents(
     block_compressions: &[CompressionPreference],
     blocks: &[BlockSize],

--- a/projects/sewer56-archives-nx/src/headers/managed/v2/table_of_contents_builder.rs
+++ b/projects/sewer56-archives-nx/src/headers/managed/v2/table_of_contents_builder.rs
@@ -36,9 +36,9 @@ pub struct BuilderInfo<LongAlloc: Allocator + Clone> {
 ///
 /// # Arguments
 ///
-/// * `blocks` - A slice of [Box<dyn Block<T>>] representing the blocks in the archive.
-/// * `chunk_size` - The maximum size of a chunk in the file. From [PackingSettings].
-/// * `max_block_size` - The maximum size of a SOLID block. From [PackingSettings].
+/// * `blocks` - A slice of [Box<dyn Block\<T\>>] representing the blocks in the archive.
+/// * `chunk_size` - The maximum size of a chunk in the file. From PackingSettings.
+/// * `max_block_size` - The maximum size of a SOLID block. From PackingSettings.
 /// * `need_hashes` - Whether to include hashes in the table of contents.
 /// * `short_alloc` - An allocator for short lived memory. Think pooled memory and rentals.
 /// * `long_alloc` - An allocator for longer lived memory. Think same lifetime as creating Nx archive creator/unpacker.

--- a/projects/sewer56-archives-nx/src/headers/managed/v2/table_of_contents_builder.rs
+++ b/projects/sewer56-archives-nx/src/headers/managed/v2/table_of_contents_builder.rs
@@ -715,7 +715,7 @@ mod tests {
 
         unsafe {
             // Write header to buffer
-            (data.as_mut_ptr() as *mut u64).write_unaligned(header.0);
+            (data.as_mut_ptr() as *mut u64).write_unaligned(header.to_le().0);
 
             let result = TableOfContents::deserialize_v2xx(data.as_ptr(), 12);
             assert!(matches!(result,

--- a/projects/sewer56-archives-nx/src/headers/parser/string_pool_common.rs
+++ b/projects/sewer56-archives-nx/src/headers/parser/string_pool_common.rs
@@ -104,7 +104,7 @@ pub unsafe fn get_unchecked<'a>(raw_data: &'a [u8], offsets: &'a [u32], index: u
 }
 
 /// Represents an error obtained when trying to pack the string pool.
-/// To see the format details, see the [StringPoolFormat::V0] and [StringPoolFormat::V1]
+/// To see the format details, see the [`StringPoolFormat::V0`]
 /// documentation.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum StringPoolFormat {

--- a/projects/sewer56-archives-nx/src/headers/raw/toc/v1/native_file_entry_v0.rs
+++ b/projects/sewer56-archives-nx/src/headers/raw/toc/v1/native_file_entry_v0.rs
@@ -7,7 +7,7 @@ use fake::*;
 /// Structure that represents the native serialized file entry.
 ///
 /// Remarks:
-/// V0 represents [`TableOfContentsVersion::V0`](crate::headers::enums::table_of_contents_version::TableOfContentsVersion::V0).
+/// V0 represents [`TableOfContentsVersion::V0`](crate::headers::enums::v1::TableOfContentsVersion::V0).
 #[repr(C, packed(4))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]
 pub struct NativeFileEntryV0 {

--- a/projects/sewer56-archives-nx/src/headers/raw/toc/v1/native_file_entry_v1.rs
+++ b/projects/sewer56-archives-nx/src/headers/raw/toc/v1/native_file_entry_v1.rs
@@ -5,7 +5,7 @@ use core::hash::Hash;
 /// Structure that represents the native serialized file entry.
 ///
 /// Remarks:
-/// V1 represents [`TableOfContentsVersion::V1`](crate::headers::enums::table_of_contents_version::TableOfContentsVersion::V1)
+/// V1 represents [`TableOfContentsVersion::V1`](crate::headers::enums::v1::TableOfContentsVersion::V1)
 /// in legacy v1.x.x archives (File Header Version: 0)
 #[repr(C, packed(8))]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default)]

--- a/projects/sewer56-archives-nx/src/headers/raw/toc/v2/fef64/toc_header.rs
+++ b/projects/sewer56-archives-nx/src/headers/raw/toc/v2/fef64/toc_header.rs
@@ -93,7 +93,7 @@ impl Fef64TocHeader {
     ///
     /// A new `TocHeader` instance.
     pub fn from_raw(raw: u64) -> Self {
-        Fef64TocHeader(raw.to_le())
+        Fef64TocHeader(raw)
     }
 
     /// Converts the `TocHeader` to little-endian format.

--- a/projects/sewer56-archives-nx/src/headers/raw/toc/v2/presets/preset0_header.rs
+++ b/projects/sewer56-archives-nx/src/headers/raw/toc/v2/presets/preset0_header.rs
@@ -89,7 +89,7 @@ impl Preset0TocHeader {
     ///
     /// A new `Preset0TocHeader` instance.
     pub fn from_raw(raw: u64) -> Self {
-        Preset0TocHeader(raw.to_le())
+        Preset0TocHeader(raw)
     }
 
     /// Converts the `Preset0TocHeader` to little-endian format.
@@ -178,7 +178,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_endian = "big", ignore = "currently fails on big endian")]
     fn from_raw_creates_correct_header() {
         let raw: u64 = 0x000123456789ABCDE;
         let header = Preset0TocHeader::from_raw(raw);

--- a/projects/sewer56-archives-nx/src/headers/raw/toc/v2/presets/preset3_header.rs
+++ b/projects/sewer56-archives-nx/src/headers/raw/toc/v2/presets/preset3_header.rs
@@ -89,7 +89,7 @@ impl Preset3TocHeader {
     /// A new `Preset3TocHeader` instance.
     #[cfg_attr(feature = "nightly", coverage(off))]
     pub fn from_raw(raw: u64) -> Self {
-        Preset3TocHeader(raw.to_le())
+        Preset3TocHeader(raw)
     }
 
     /// Converts the `Preset3TocHeader` to little-endian format.

--- a/projects/sewer56-archives-nx/src/implementation/pack/blocks/polyfills.rs
+++ b/projects/sewer56-archives-nx/src/implementation/pack/blocks/polyfills.rs
@@ -186,7 +186,7 @@ where
     /// # Arguments
     ///
     /// * `start_offset` - The starting offset of the block
-    /// * `chunk_size` - The size of the block at [`Self::start_offset`].
+    /// * `chunk_size` - The size of the block at the start offset.
     /// * `chunk_index` - The index of the block
     /// * `state` - The shared state of all chunks
     pub fn new(

--- a/projects/sewer56-archives-nx/src/utilities/compression/copy.rs
+++ b/projects/sewer56-archives-nx/src/utilities/compression/copy.rs
@@ -7,7 +7,7 @@ pub use zstd_sys::ZSTD_ErrorCode;
 ///
 /// This enum contains only errors that originate from copy operations and maintains
 /// consistency with other compression algorithm error types. High-level validation
-/// errors are handled by [`NxDecompressionError`] variants.
+/// errors are handled by [`super::NxDecompressionError`] variants.
 ///
 /// # Error Mappings
 ///

--- a/projects/sewer56-archives-nx/src/utilities/compression/dictionary/train.rs
+++ b/projects/sewer56-archives-nx/src/utilities/compression/dictionary/train.rs
@@ -24,7 +24,7 @@ pub fn has_enough_samples_for_dictionary(num_samples: usize) -> bool {
 /// # Returns
 ///
 /// The trained dictionary data on success.
-/// May return [`ZSTD_error_srcSize_wrong`] if there are not enough samples.
+/// May return `ZSTD_error_srcSize_wrong` if there are not enough samples.
 pub fn train_dictionary(
     samples: &[&[u8]],
     dict_size: usize,

--- a/projects/sewer56-archives-nx/src/utilities/compression/lz4.rs
+++ b/projects/sewer56-archives-nx/src/utilities/compression/lz4.rs
@@ -28,7 +28,7 @@ pub enum Lz4CompressionError {
 ///
 /// This enum contains only errors that originate from the underlying LZ4 library
 /// and are passed through without interpretation. High-level validation
-/// errors are handled by [`NxDecompressionError`] variants.
+/// errors are handled by [`super::NxDecompressionError`] variants.
 ///
 /// # Error Code Mappings
 ///

--- a/projects/sewer56-archives-nx/src/utilities/compression/mod.rs
+++ b/projects/sewer56-archives-nx/src/utilities/compression/mod.rs
@@ -8,8 +8,8 @@
 //! The compression system uses a two-tier error handling approach:
 //!
 //! ## Raw Library Errors
-//! Each compression algorithm has its own error type (e.g., [`bzip3::Bzip3CompressionError`],
-//! [`lz4::Lz4CompressionError`]) that contains **only** raw errors returned directly from
+//! Each compression algorithm has its own error type (e.g., [`Bzip3CompressionError`],
+//! [`Lz4CompressionError`]) that contains **only** raw errors returned directly from
 //! the underlying compression libraries. These errors are passed through without
 //! interpretation and represent low-level library failures.
 //!
@@ -22,6 +22,14 @@
 //!
 //! This separation ensures that validation logic is consistent across all algorithms
 //! while preserving the ability to handle algorithm-specific library errors.
+//!
+//! [`Bzip3CompressionError`]: crate::utilities::compression::bzip3::Bzip3CompressionError
+//! [`Lz4CompressionError`]: crate::utilities::compression::lz4::Lz4CompressionError
+//! [`NxCompressionError`]: crate::utilities::compression::NxCompressionError
+//! [`NxDecompressionError`]: crate::utilities::compression::NxDecompressionError
+//! [`NxCompressionError::DestinationTooSmall`]: crate::utilities::compression::NxCompressionError::DestinationTooSmall
+//! [`NxDecompressionError::MaxBlockSizeNotProvided`]: crate::utilities::compression::NxDecompressionError::MaxBlockSizeNotProvided
+//! [`NxDecompressionError::MaxBlockSizeTooSmall`]: crate::utilities::compression::NxDecompressionError::MaxBlockSizeTooSmall
 
 // Compression modules
 pub mod copy;


### PR DESCRIPTION
## Summary

Fixes documentation formatting and adds big-endian compatibility support across the codebase.

## Changes

- Fix rustdoc formatting in 20+ files using proper `[`Type`]` syntax instead of `Type`
- Resolve big-endian test failures by ensuring little-endian header format in ToC headers
- Add cross-compilation targets for PowerPC big-endian architectures to Nix flake
- Create AGENTS.md with comprehensive project coding standards and verification steps
- Fix broken documentation links and references throughout the codebase

## Purpose

Improve code maintainability with consistent documentation standards and ensure cross-platform compatibility by fixing big-endian architecture support.

## Modified Files

- `AGENTS.md` - New coding standards and verification guidelines
- `flake.nix` - Added PowerPC cross-compilation targets
- `src/headers/raw/toc/v2/*` - Fixed big-endian header deserialization
- `src/api/filedata/input/*` - Fixed documentation references  
- `src/utilities/compression/*` - Updated rustdoc formatting
- Various other files - Documentation formatting improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Corrected header endianness handling to improve behavior across architectures.

- Documentation
  - Added comprehensive contributor/project guidelines.
  - Updated and clarified numerous inline docs and type references across the codebase.

- Tests
  - Expanded CI to cover big-endian PowerPC targets and re-enabled a previously skipped big-endian test.

- Chores
  - Expanded dev environment with additional PowerPC tool targets and enabled a cross-compilation flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->